### PR TITLE
Opt GitHub Actions into Node 24 runtime

### DIFF
--- a/.github/workflows/generate-data.yml
+++ b/.github/workflows/generate-data.yml
@@ -13,6 +13,9 @@ on:
   schedule:
     - cron: "1 0 * * 0"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,9 @@ on:
       - reopened
       - ready_for_review
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- opt workflows into the Node 24 JavaScript actions runtime
- keep GitHub Actions versions aligned with the Node 24 migration
- apply the runtime flag to both CI workflows

## Testing
- not run locally; workflow-only change