### PR TITLE
Add footer and responsive toolbar layout

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,64 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import type {
 const SELECTIONS_COOKIE_KEY = "tt_selection_v1";
 const SELECTIONS_COOKIE_DAYS = 7;
 const SUBDOMAIN = "tera";
+const COPYRIGHT_YEAR = 2026;
 
 type Page = "home" | "setup" | "timetable";
 type SetupResolver = {
@@ -30,6 +31,37 @@ interface SetupViewState {
 	pre: string;
 	options: SetupOption[];
 	defaultValue: string | number | null;
+}
+
+function AppFooter() {
+	return (
+		<footer className="site-footer">
+			<div className="site-footer_grid">
+			<div className="site-footer__section">
+				<h2 className="site-footer__title">GitHub</h2>
+				<p>
+					<a className="lnk" href="https://github.com/hacker30083/tt">Repository</a>
+				</p>
+				<p>
+					<a className="lnk" href="https://github.com/hacker30083/tt/blob/main/README.md">README</a>
+				</p>
+			</div>
+			<div className="site-footer__section">
+				<h2 className="site-footer__title">Kontakt</h2>
+				<p>
+					<a className="lnk" href="https://github.com/hacker30083">hacker30083+github@hotmail.com</a>
+				</p>
+				<p>
+					<a className="lnk" href="https://github.com/hacker30083/tt/issues">Issues</a>
+				</p>
+			</div>
+			</div>
+			<div className="site-footer__copyright">
+				<p>&copy; 2024-{COPYRIGHT_YEAR} mk4i and Kaspar Aun (hacker30083)</p>
+				<p>All rights reserved.</p>
+			</div>
+		</footer>
+	);
 }
 
 function getURLParams(url: string | URL): Record<string, string> {
@@ -491,6 +523,7 @@ export default function App() {
 					<button className="primary large" type="button" onClick={() => void setup()}>
 						Koosta →
 					</button>
+					<AppFooter />
 				</div>
 			</div>
 
@@ -517,6 +550,7 @@ export default function App() {
 							</button>
 						))}
 					</div>
+					<AppFooter />
 				</div>
 			</div>
 
@@ -538,9 +572,8 @@ export default function App() {
 					</div>
 				)}
 
-				<hr />
 
-				<div className="flex">
+				<div className="flex toolbar-grid">
 					<button type="button" onClick={() => void setup()}>Genereeri tunniplaan</button>
 					<button type="button" onClick={clearAll}>Kustuta küpsised</button>
 					<button type="button" onClick={() => void share()}>Kopeeri link</button>
@@ -552,6 +585,7 @@ export default function App() {
 					</button>
 					<button type="button" onClick={() => void downloadElementByID("tt")}>Laadi alla</button>
 				</div>
+				<AppFooter />
 			</div>
 		</>
 	);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -142,14 +142,87 @@ input {
 	gap: 0 .5rem;
 }
 
+.toolbar-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+	gap: 0.75rem;
+	width: min(100%, 78rem);
+	align-self: stretch;
+}
+
+.toolbar-grid button {
+	width: 100%;
+	margin: 0;
+}
+
+.site-footer {
+	width: min(100%, 42rem);
+	margin-top: 1.5rem;
+	padding-top: 1rem;
+	border-top: 0.04rem solid var(--gray);
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	align-self: stretch;
+}
+
+.site-footer_grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 1rem;
+}
+
+.site-footer__section {
+	min-width: 0;
+}
+
+.site-footer__title {
+	padding-bottom: 0.35rem;
+	font-weight: 700;
+	color: var(--fg);
+	font-size: 200%;
+
+}
+
+.site-footer__copyright {
+	text-align: center;
+	font-size: small;
+	font-weight: 300;
+	padding-top: 0.5rem;
+	border-top: 0.04rem solid var(--gray);
+}
+
+.site-footer p{
+	padding: 0.15rem 0;
+	color: var(--light-fg);
+	font-weight: 300;
+	font-size: 125%;
+}
+
+@media (max-width: 40rem) {
+	.site-footer_grid {
+		grid-template-columns: 1fr;
+	}
+}
+
 .flex button {
 	flex: 1 1;
 	text-wrap: nowrap;
 }
 
 .opt {
-	flex-grow: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+	gap: 0.75rem;
+	width: 100%;
+	flex-grow: 1;
 	height: min-content;
+	align-items: stretch;
+}
+
+.opt button {
+	width: 100%;
+	margin: 0;
 }
 
 button {


### PR DESCRIPTION
## Summary
- add a reusable footer with GitHub/contact links and copyright text
- lay out the footer in side-by-side columns with copyright underneath
- make the timetable action buttons fill horizontal space in a responsive grid